### PR TITLE
Adjust alignment of `+` icon

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@demoflow/editor",
-  "version": "1.0.4",
+  "version": "1.0.4-RC1",
   "description": "Editor.js — Native JS, based on API and Open Source",
   "main": "dist/editor.js",
   "types": "./types/index.d.ts",
@@ -30,7 +30,8 @@
     "_tools:make": "yarn _tools:yarn && yarn _tools:build",
     "tools:update": "yarn _tools:checkout && yarn _tools:pull && yarn _tools:make",
     "test:e2e": "yarn build && cypress run",
-    "test:e2e:open": "yarn build && cypress open"
+    "test:e2e:open": "yarn build && cypress open",
+    "publish:assets": "pm run build && npm publish"
   },
   "author": "CodeX",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@demoflow/editor",
-  "version": "1.0.4",
+  "version": "1.0.4-RC1",
   "description": "Editor.js — Native JS, based on API and Open Source",
   "main": "dist/editor.js",
   "types": "./types/index.d.ts",
@@ -31,7 +31,7 @@
     "tools:update": "yarn _tools:checkout && yarn _tools:pull && yarn _tools:make",
     "test:e2e": "yarn build && cypress run",
     "test:e2e:open": "yarn build && cypress open",
-    "publish:assets": "pm run build && npm publish"
+    "publish:assets": "npm run build && npm publish"
   },
   "author": "CodeX",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@demoflow/editor",
-  "version": "1.0.4-RC1",
+  "version": "1.0.4",
   "description": "Editor.js — Native JS, based on API and Open Source",
   "main": "dist/editor.js",
   "types": "./types/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@demoflow/editor",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Editor.js — Native JS, based on API and Open Source",
   "main": "dist/editor.js",
   "types": "./types/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@demoflow/editor",
-  "version": "1.0.4-RC1",
+  "version": "1.0.5",
   "description": "Editor.js — Native JS, based on API and Open Source",
   "main": "dist/editor.js",
   "types": "./types/index.d.ts",

--- a/src/codex.ts
+++ b/src/codex.ts
@@ -89,6 +89,7 @@ export default class EditorJS {
           }
           moduleInstance.listeners.removeAll();
         });
+      console.log('in editor');
 
       editor = null;
 

--- a/src/codex.ts
+++ b/src/codex.ts
@@ -89,7 +89,6 @@ export default class EditorJS {
           }
           moduleInstance.listeners.removeAll();
         });
-      console.log('in editor');
 
       editor = null;
 

--- a/src/components/modules/toolbar/index.ts
+++ b/src/components/modules/toolbar/index.ts
@@ -89,7 +89,7 @@ export default class Toolbar extends Module<ToolbarNodes> {
   constructor({ config, eventsDispatcher }: ModuleConfig) {
     super({
       config,
-      eventsDispatcher
+      eventsDispatcher,
     });
     this.tooltip = new Tooltip();
   }
@@ -115,7 +115,7 @@ export default class Toolbar extends Module<ToolbarNodes> {
 
       // Actions Zone
       blockActionsButtons: 'ce-toolbar__actions-buttons',
-      settingsToggler: 'ce-toolbar__settings-btn'
+      settingsToggler: 'ce-toolbar__settings-btn',
     };
   }
 
@@ -142,7 +142,7 @@ export default class Toolbar extends Module<ToolbarNodes> {
           return;
         }
         this.nodes.plusButton.classList.remove(this.CSS.plusButtonHidden);
-      }
+      },
     };
   }
 
@@ -158,7 +158,7 @@ export default class Toolbar extends Module<ToolbarNodes> {
       },
       show: (): void => {
         this.nodes.actions.classList.add(this.CSS.actionsOpened);
-      }
+      },
     };
   }
 
@@ -209,8 +209,8 @@ export default class Toolbar extends Module<ToolbarNodes> {
      * 2) On mobile — Toolbar at the bottom of Block
      */
     if (!isMobile) {
-      this.nodes.plusButton.style.transform = `translate3d(0, 300, 0)`;
-      this.Editor.Toolbox.nodes.toolbox.style.transform = `translate3d(0, 300, 0)`;
+      this.nodes.plusButton.style.transform = `translate3d(0, 0, 0)`;
+      this.Editor.Toolbox.nodes.toolbox.style.transform = `translate3d(0, 0, 0)`;
     } else {
       toolbarY += blockHeight;
     }
@@ -305,7 +305,7 @@ export default class Toolbar extends Module<ToolbarNodes> {
     );
     tooltipContent.appendChild(
       $.make('div', this.CSS.plusButtonShortcut, {
-        textContent: '⇥ Tab'
+        textContent: '⇥ Tab',
       })
     );
 
@@ -329,7 +329,7 @@ export default class Toolbar extends Module<ToolbarNodes> {
       this.nodes.settingsToggler,
       I18n.ui(I18nInternalNS.ui.blockTunes.toggler, 'Click to tune'),
       {
-        placement: 'top'
+        placement: 'top',
       }
     );
 

--- a/src/components/modules/toolbar/index.ts
+++ b/src/components/modules/toolbar/index.ts
@@ -192,6 +192,7 @@ export default class Toolbar extends Module<ToolbarNodes> {
     }
 
     const currentBlock = this.Editor.BlockManager.currentBlock.holder;
+    const currentBlockIsEmpty = this.Editor.BlockManager.currentBlock.isEmpty;
 
     /**
      * If no one Block selected as a Current
@@ -202,6 +203,7 @@ export default class Toolbar extends Module<ToolbarNodes> {
 
     const { isMobile } = this.Editor.UI;
     const blockHeight = currentBlock.offsetHeight;
+
     let toolbarY = currentBlock.offsetTop;
 
     /**
@@ -213,7 +215,9 @@ export default class Toolbar extends Module<ToolbarNodes> {
     if (!isMobile) {
       this.nodes.plusButton.style.transform = `translate3d(0, 0, 0)`;
     } else {
-      toolbarY += (blockHeight / 2);
+      // if (currentBlockIsEmpty) {
+      //   toolbarY += (blockHeight / 2);
+      // }
     }
 
     /**

--- a/src/components/modules/toolbar/index.ts
+++ b/src/components/modules/toolbar/index.ts
@@ -208,11 +208,12 @@ export default class Toolbar extends Module<ToolbarNodes> {
      * 1) On desktop — Toolbar at the top of Block, Plus/Toolbox moved the center of Block
      * 2) On mobile — Toolbar at the bottom of Block
      */
+    this.Editor.Toolbox.nodes.toolbox.style.transform = `translate3d(0, 0, 0)`;
+
     if (!isMobile) {
       this.nodes.plusButton.style.transform = `translate3d(0, 0, 0)`;
-      this.Editor.Toolbox.nodes.toolbox.style.transform = `translate3d(0, 0, 0)`;
     } else {
-      toolbarY += blockHeight;
+      toolbarY += (blockHeight / 2);
     }
 
     /**

--- a/src/components/modules/toolbar/index.ts
+++ b/src/components/modules/toolbar/index.ts
@@ -192,7 +192,6 @@ export default class Toolbar extends Module<ToolbarNodes> {
     }
 
     const currentBlock = this.Editor.BlockManager.currentBlock.holder;
-    const currentBlockIsEmpty = this.Editor.BlockManager.currentBlock.isEmpty;
 
     /**
      * If no one Block selected as a Current
@@ -202,9 +201,7 @@ export default class Toolbar extends Module<ToolbarNodes> {
     }
 
     const { isMobile } = this.Editor.UI;
-    const blockHeight = currentBlock.offsetHeight;
-
-    let toolbarY = currentBlock.offsetTop;
+    const toolbarY = currentBlock.offsetTop;
 
     /**
      * 1) On desktop — Toolbar at the top of Block, Plus/Toolbox moved the center of Block
@@ -214,10 +211,6 @@ export default class Toolbar extends Module<ToolbarNodes> {
 
     if (!isMobile) {
       this.nodes.plusButton.style.transform = `translate3d(0, 0, 0)`;
-    } else {
-      // if (currentBlockIsEmpty) {
-      //   toolbarY += (blockHeight / 2);
-      // }
     }
 
     /**

--- a/src/components/modules/tools.ts
+++ b/src/components/modules/tools.ts
@@ -204,41 +204,41 @@ export default class Tools extends Module {
     [toolName: string]:
       | ToolConstructable
       | (ToolSettings & { isInternal?: boolean });
-  } {
+      } {
     return {
       bold: {
         class: BoldInlineTool,
-        isInternal: true
+        isInternal: true,
       },
       italic: {
         class: ItalicInlineTool,
-        isInternal: true
+        isInternal: true,
       },
       link: {
         class: LinkInlineTool,
-        isInternal: true
+        isInternal: true,
       },
       paragraph: {
         class: Paragraph,
         inlineToolbar: true,
-        isInternal: true
+        isInternal: true,
       },
       stub: {
         class: Stub,
-        isInternal: true
+        isInternal: true,
       },
       moveUp: {
         class: MoveUpTune,
-        isInternal: true
+        isInternal: true,
       },
       delete: {
         class: DeleteTune,
-        isInternal: true
+        isInternal: true,
       },
       moveDown: {
         class: MoveDownTune,
-        isInternal: true
-      }
+        isInternal: true,
+      },
     };
   }
 
@@ -305,13 +305,11 @@ export default class Tools extends Module {
     Object.entries(config).forEach(([toolName, settings]) => {
       toolPreparationList.push({
         // eslint-disable-next-line @typescript-eslint/no-empty-function
-        function: _.isFunction(settings.class.prepare)
-          ? settings.class.prepare
-          : (): void => {},
+        function: _.isFunction(settings.class.prepare) ? settings.class.prepare : (): void => {},
         data: {
           toolName,
-          config: settings.config
-        }
+          config: settings.config,
+        },
       });
     });
 
@@ -348,15 +346,15 @@ export default class Tools extends Module {
      */
     if (tool.enabledInlineTools === true) {
       tool.inlineTools = new ToolsCollection<InlineTool>(
+        /**
+         * If common settings is 'true' or not specified (will be set as true at core.ts), get the default order
+         */
         Array.isArray(this.config.inlineToolbar)
           ? this.config.inlineToolbar.map((name) => [
-              name,
-              this.inlineTools.get(name)
-            ])
-          : /**
-             * If common settings is 'true' or not specified (will be set as true at core.ts), get the default order
-             */
-            Array.from(this.inlineTools.entries())
+            name,
+            this.inlineTools.get(name),
+          ])
+          : Array.from(this.inlineTools.entries())
       );
 
       return;
@@ -389,7 +387,7 @@ export default class Tools extends Module {
 
       tool.tunes = new ToolsCollection<BlockTune>([
         ...userTunes,
-        ...this.blockTunes.internalTools
+        ...this.blockTunes.internalTools,
       ]);
 
       return;
@@ -402,7 +400,7 @@ export default class Tools extends Module {
 
       tool.tunes = new ToolsCollection<BlockTune>([
         ...userTunes,
-        ...this.blockTunes.internalTools
+        ...this.blockTunes.internalTools,
       ]);
 
       return;
@@ -453,7 +451,7 @@ export default class Tools extends Module {
         config[toolName] = this.config.tools[toolName] as ToolSettings;
       } else {
         config[toolName] = {
-          class: this.config.tools[toolName] as ToolConstructable
+          class: this.config.tools[toolName] as ToolConstructable,
         };
       }
     }

--- a/src/styles/block.css
+++ b/src/styles/block.css
@@ -79,8 +79,7 @@
 }
 
 .codex-editor--narrow {
-  margin-left: 5px;
   .ce-block {
-    margin-right: 0;
+    max-width: 90%;
   }
 }

--- a/src/styles/block.css
+++ b/src/styles/block.css
@@ -1,4 +1,5 @@
 .ce-block {
+  max-width: 90%;
   &:first-of-type {
     margin-top: 0;
   }
@@ -26,7 +27,7 @@
 
   &__content {
     position: relative;
-    max-width: var(--content-width);
+    max-width: 90%;
     margin: 0 auto;
     transition: background-color 150ms ease;
   }
@@ -77,6 +78,9 @@
   }
 }
 
-.codex-editor--narrow .ce-block--focused {
-  padding-right: 0 !important;
+.codex-editor--narrow {
+  margin-left: 5px;
+  .ce-block {
+    margin-right: 0;
+  }
 }

--- a/src/styles/toolbar.css
+++ b/src/styles/toolbar.css
@@ -3,6 +3,8 @@
   left: 0;
   right: 0;
   top: 0;
+  z-index: 0;
+  max-width: 90%;
   /*opacity: 0;*/
   /*visibility: hidden;*/
   transition: opacity 100ms ease;
@@ -24,10 +26,9 @@
   }
 
   &__content {
-    max-width: var(--content-width);
     margin: 0 auto;
     position: relative;
-
+    max-width: 90%;
     /* @media (--mobile){
       display: flex;
       align-content: center;
@@ -40,7 +41,7 @@
     @apply --toolbox-button;
 
     position: absolute;
-    left: calc(var(--toolbox-buttons-size) * -1);
+    left: 12px;
     flex-shrink: 0;
 
     &-shortcut {
@@ -113,10 +114,11 @@
  * Styles for Narrow mode
  */
 .codex-editor--narrow .ce-toolbar__plus {
+  z-index: 0;
   @media (--not-mobile) {
     left: 5px;
   }
-  @media (--pmd){
+  @media (--mobile){
     transform: translate(5px, 0);
   }
 }

--- a/src/styles/toolbar.css
+++ b/src/styles/toolbar.css
@@ -52,12 +52,6 @@
     &--hidden {
       display: none;
     }
-
-    /* @media (--mobile){
-      display: inline-flex !important;
-      position: static;
-      transform: none !important;
-    } */
   }
 
   &__plus,
@@ -121,5 +115,8 @@
 .codex-editor--narrow .ce-toolbar__plus {
   @media (--not-mobile) {
     left: 5px;
+  }
+  @media (--pmd){
+    transform: translate(5px, 0);
   }
 }

--- a/src/styles/toolbar.css
+++ b/src/styles/toolbar.css
@@ -67,7 +67,7 @@
    */
   &__actions {
     position: absolute;
-    right: -30px;
+    right: -20px;
     top: 5px;
     opacity: 0;
 
@@ -114,11 +114,5 @@
  * Styles for Narrow mode
  */
 .codex-editor--narrow .ce-toolbar__plus {
-  z-index: 0;
-  @media (--not-mobile) {
-    left: 5px;
-  }
-  @media (--mobile){
-    transform: translate(5px, 0);
-  }
+  transform: translate(0, 0);
 }

--- a/src/styles/toolbox.css
+++ b/src/styles/toolbox.css
@@ -5,6 +5,7 @@
   will-change: opacity;
   display: flex;
   flex-direction: row;
+  background-color: white;
 
   /* @media (--mobile){
     position: static;

--- a/src/styles/ui.css
+++ b/src/styles/ui.css
@@ -5,7 +5,6 @@
   position: relative;
   box-sizing: border-box;
   z-index: 1;
-  height: 100%;
   overflow-y: auto;
   background-color: white;
 
@@ -15,6 +14,7 @@
 
   &__redactor {
     height: 100%;
+    margin-right: 0;
     &--hidden {
       display: none;
     }
@@ -46,9 +46,6 @@
 
   &--narrow .ce-toolbar__actions {
     z-index: 0;
-    @media (--not-mobile) {
-      right: -5px;
-    }
   }
 
   &__loader {

--- a/src/styles/ui.css
+++ b/src/styles/ui.css
@@ -5,12 +5,16 @@
   position: relative;
   box-sizing: border-box;
   z-index: 1;
+  height: 100%;
+  overflow-y: auto;
+  background-color: white;
 
   .hide {
     display: none;
   }
 
   &__redactor {
+    height: 100%;
     &--hidden {
       display: none;
     }
@@ -41,6 +45,7 @@
   }
 
   &--narrow .ce-toolbar__actions {
+    z-index: 0;
     @media (--not-mobile) {
       right: -5px;
     }

--- a/src/styles/variables.css
+++ b/src/styles/variables.css
@@ -1,5 +1,6 @@
 @custom-media --mobile (width <= 650px);
 @custom-media --not-mobile (width >= 651px);
+@custom-media --pmd (width <= 400px);
 
 :root {
   /**


### PR DESCRIPTION
also fixes eslint errors for trailing commas and bad line break

Carries over override styling from `demoflow_client` to css files here.

Redo styling of toolbar, toolbox, plus button, and content blocks to be consistent across sizes for better UX

### Before
**PMD**
![Image 2021-11-11 at 11 51 37 AM](https://user-images.githubusercontent.com/42350975/141352899-c75414ca-4cf6-4c09-b783-dc4cb0d2dc80.jpg)

**Dashboard**
![Image 2021-11-12 at 3 59 15 PM](https://user-images.githubusercontent.com/42350975/141591136-75cd6ac5-e1f5-45c4-82d6-b583a4035cbc.jpg)
![Image 2021-11-12 at 3 59 41 PM](https://user-images.githubusercontent.com/42350975/141591237-2a33ed6c-549c-4eef-bdcc-fe9798e4a3de.jpg)


### After
**PMD:**
https://www.loom.com/share/11f0c76f357e4717b7c204924ab16144

**Dashboard:**
https://www.loom.com/share/fb95594dde12474295a548c7895329bc